### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@ pharmacovigilance activities.
   <section>
     <h2>Need, envisioned workflow, and high-level requirements</h2>
     <p>New information regarding PDDIs is published every day in primary sources such as drug product labeling and the scientific
-      literature. A PubMed search for publications indexed with the Medical Subject Headings keyword “Drug interactions” shows an
+      literature. A PubMed search for publications indexed with the Medical Subject Heading “Drug interactions” shows an
       average of 3,970 publications per year from 2000 through 2016. This suggests that the body of evidence about PDDIs is
       overwhelming and dynamic. As it is impossible for clinicians to keep up with the PDDI evidence base, drug
       experts generate summaries of PDDI evidence from primary sources. These summaries bring PDDI knowledge to clinicians


### PR DESCRIPTION
Subject headings are categories, not keywords. Removed reference to MeSH as a keyword. Alternately, refer to it as a "term"., But I think 'with the Medical Subject Heading “Drug interactions”' suffices.