### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -967,7 +967,7 @@ pharmacovigilance activities.
       average of 3,970 publications per year from 2000 through 2016. This suggests that the body of evidence about PDDIs is
       overwhelming and dynamic. As it is impossible for clinicians to keep up with the PDDI evidence base, drug
       experts generate summaries of PDDI evidence from primary sources. These summaries bring PDDI knowledge to clinicians
-      in the form of published drug information compendium, clinical decision support rules, and interaction checking applications.
+      in the form of published drug information compendia, clinical decision support rules, and interaction checking applications.
       <strong>However, there are currently no broadly accepted standards to guide these experts in the organization and presentation of PDDI
         information.</strong>
     </p>


### PR DESCRIPTION
Compendia (as plural), to match the rest of the sentence. "These summaries bring PDDI knowledge to clinicians
      in the form of published drug information compendia, clinical decision support rules, and interaction checking applications."